### PR TITLE
Fix for fanstatic 1.0a3 / separate publisher and injector tweens

### DIFF
--- a/pyramid_fanstatic/__init__.py
+++ b/pyramid_fanstatic/__init__.py
@@ -2,13 +2,9 @@
 from fanstatic.config import convert_config
 from fanstatic.publisher import Publisher
 import fanstatic
-import logging
 import os
 import wsgiref.util
 from pyramid.settings import asbool
-
-log = logging.getLogger(__name__)
-
 
 def fanstatic_config(config, prefix='fanstatic.'):
     cfg = {'publisher_signature': fanstatic.DEFAULT_SIGNATURE}

--- a/pyramid_fanstatic/tests.py
+++ b/pyramid_fanstatic/tests.py
@@ -90,7 +90,8 @@ class TestCustomConfigUseApplicationUri(TestCustomConfig):
     def setUp(self):
         """Set up and add dummy route to webtest application."""
         super(TestCustomConfigUseApplicationUri, self).setUp()
-        self.config.add_route('dummy', '/subdir/page', view=home) #dummy route
+        self.config.add_route('dummy', '/subdir/page') #dummy route
+        self.config.add_view(home, route_name='dummy')
         self.app = TestApp(self.config.make_wsgi_app())
 
     def test_base_url_is_set(self):

--- a/pyramid_fanstatic/tests.py
+++ b/pyramid_fanstatic/tests.py
@@ -7,6 +7,8 @@ from webtest import TestApp
 from js.jquery import jquery
 import fanstatic
 
+if not hasattr(unittest.TestCase, 'assertNotIn'):
+    import unittest2 as unittest
 
 def home(request):
     resp = request.response


### PR DESCRIPTION
This series of commits:
- Fixes things to work with the new pluggable injector architecture in fanstatic 1.0a3
- Splits `Tween` into `PublisherTween` and `InjectorTween`
- Various other small cleanups/fixes

Sorry for putting them all in a single pull request.  If you'd like them split up, let me know.
